### PR TITLE
4カラムのヘッダ要素にクラスを追加

### DIFF
--- a/app/views/yukiusagi/top.html.erb
+++ b/app/views/yukiusagi/top.html.erb
@@ -1,5 +1,5 @@
 <div class="yu-alert"><p>【アラート】ゆきうさぎをインストールしてくれてありがとう！</p><i class="fas fa-times"></i></div>
-<div class="yu-wrap">
+<div class="yu-wrap yu-wrap-head">
   <div class="yu-head-box pink">
     <i class="fas fa-laptop"></i>
     <h3><span>日本語の見出し</span>HEADING</h3>


### PR DESCRIPTION
<img width="721" alt="2019-03-07 17 13 35" src="https://user-images.githubusercontent.com/37989764/53941777-5d22aa80-40fc-11e9-8a35-96edbcdb2b7c.png">
カラム崩れを起こしていたヘッダ要素にクラスを追加しました。

### できていないこと（これから修正すること）
各要素の横幅が大きい（右にずれてしまっている）ので修正する