### PR TITLE
依存gemをfont-awesome-sassに修正

### DIFF
--- a/yukiusagi.gemspec
+++ b/yukiusagi.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "jquery-rails"
-  spec.add_dependency "font-awesome-rails"
+  spec.add_dependency "font-awesome-sass", "~> 5.6.1"
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
依存gemを `font-awesome-rails`から `font-awesome-sass`に修正